### PR TITLE
Server View

### DIFF
--- a/src/hide-discord-sidebar.js
+++ b/src/hide-discord-sidebar.js
@@ -62,7 +62,7 @@ const HDS = {
     }
 
     const btn = document.createElement("BUTTON");
-    const t = document.createTextNode("Hide Servers");
+    const t = document.createTextNode("");
     btn.appendChild(t);
     btn.id = "hds-btn";
     btn.onclick = () => {
@@ -88,16 +88,8 @@ const HDS = {
   resizeHandler() {
     // only if extension is active
     if (this.state.active) {
-      if (this.state.servers == "server-autohide") {
-        if (window.innerWidth <= this.state.smallWindowWidth) {
-          this.hideServers();
-        } else {
-          this.showServers();
-        }
-      }
-      if (this.state.channels == "channel-autohide") {
-        document.body.classList.toggle("channel-hide", window.innerWidth <= this.state.smallWindowWidth);
-      }
+      this.hideServers();
+      document.body.classList.toggle("channel-hide", false);
     }
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,20 +1,17 @@
 {
-  "name": "Hide Discord Sidebar",
-  "short_name": "Hide Dis Bar",
-  "version": "4.4.0",
-  "description": "Hide Discord Servers and Channels! Installs a button that hides/shows the Discord server list and autohides the channels list.",
+  "name": "Discord Server View",
+  "short_name": "Dis Serv View",
+  "version": "1.1.0",
+  "description": "Provide a server specific view for Discord.",
   "manifest_version": 3,
   "icons": {
-    "128": "icons/icon128-active.png"
+    "128": "icons/icon128-active.png",
+    "default_icon": "icons/icon128-inactive.png"
   },
   "permissions": ["scripting","storage"],
   "host_permissions": ["*://*.discord.com/*"],
   "background": {
     "service_worker": "background.js"
-  },
-  "action": {
-    "default_icon": "icons/icon128-inactive.png",
-    "default_popup": "popup/popup.html"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"


### PR DESCRIPTION
This is an example of the server view I mentions in my Ko-Fi donation. I am trying my best to figure out this code but I am not a programmer. I was thinking to create a new extension that does this based on your excellent work. 

The server view provides a default endpoint for the extension. You enter the discord server channel URL in the manage page and whenever you click the extension it takes you to that server with server list off and the channel view on. This allow you to create a server specific website! It means users do not see the rest of Discord which is ideally the experience I am trying to create. It enables you to create an web hosted communications environment for a specific purpose.

Thanks Kindly