### PR TITLE
Fix UI overlap in Firefox

### DIFF
--- a/src/hide-discord-sidebar.css
+++ b/src/hide-discord-sidebar.css
@@ -51,6 +51,11 @@ body.hide-dis-bar.channel-hide div[class*="sidebarList"]:hover > * {
   /* display: flex; */
 }
 
+/* Fix layout issue in Firefox */
+body.hide-dis-bar div[class^="sidebar_"] {
+  width: auto;
+}
+
 #hds-popup {
   display: none;
   justify-content: space-between; /* applies when display: flex */


### PR DESCRIPTION
When the Discord sidebar is hidden by this extension, the computed width of the sidebar div shrinks in Chrome, but for some reason, it behaves differently in Firefox. As a result, the bottom-left user bar overlaps the message input box. I found that setting `width: auto` resolves this issue. I also confirmed that this fix doesn't affect Chrome.

Before fix: 
![User bar overlapping the message input box](https://github.com/user-attachments/assets/8f20b8b8-00d7-49e9-a82a-dab148bbe49c)

After fix:
![User bar not overlapping the message input box](https://github.com/user-attachments/assets/d1e4bab0-569c-4702-beca-c00372cb8aaa)

Aside from this, I didn't encounter any major problems while running the ManifestV3 version of this extension in Firefox. You can make a Firefox release if you simply change `"service_worker": "background.js"` to `"scripts": ["background.js"]` in `manifest.json`.